### PR TITLE
Fix for Tenant ID filtering

### DIFF
--- a/nifi-cognito-authorizer/src/main/java/co/zeroae/nifi/authorization/cognito/CognitoNaiveAccessPolicyProvider.java
+++ b/nifi-cognito-authorizer/src/main/java/co/zeroae/nifi/authorization/cognito/CognitoNaiveAccessPolicyProvider.java
@@ -47,7 +47,7 @@ public class CognitoNaiveAccessPolicyProvider extends AbstractCognitoProvider
     public void onConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
         super.onConfigured(configurationContext);
 
-        policyGroupPrefix = ACCESS_POLICY_GROUP_PREFIX + tenantId;
+        policyGroupPrefix = ACCESS_POLICY_GROUP_PREFIX + tenantId + ":";
 
         final PropertyValue userGroupProviderIdentifier = configurationContext.getProperty(PROP_USER_GROUP_PROVIDER);
         if (!userGroupProviderIdentifier.isSet())
@@ -233,7 +233,7 @@ public class CognitoNaiveAccessPolicyProvider extends AbstractCognitoProvider
     }
 
     protected String getGroupName(String resource, RequestAction action) {
-        return String.join(":", policyGroupPrefix, action.toString(), resource);
+        return policyGroupPrefix + action + ":" + resource;
     }
 
     protected Map.Entry<String, RequestAction> getResourceAndAction(String groupName) {

--- a/nifi-registry-cognito-extensions/src/main/java/co/zeroae/nifi/registry/authorization/cognito/CognitoNaiveAccessPolicyProvider.java
+++ b/nifi-registry-cognito-extensions/src/main/java/co/zeroae/nifi/registry/authorization/cognito/CognitoNaiveAccessPolicyProvider.java
@@ -44,7 +44,7 @@ public class CognitoNaiveAccessPolicyProvider extends AbstractCognitoProvider im
     public void onConfigured(AuthorizerConfigurationContext configurationContext) throws SecurityProviderCreationException {
         super.onConfigured(configurationContext);
 
-        policyGroupPrefix = ACCESS_POLICY_GROUP_PREFIX + tenantId;
+        policyGroupPrefix = ACCESS_POLICY_GROUP_PREFIX + tenantId + ":";
 
         final PropertyValue userGroupProviderIdentifier = configurationContext.getProperty(PROP_USER_GROUP_PROVIDER);
         if (!userGroupProviderIdentifier.isSet())
@@ -220,7 +220,6 @@ public class CognitoNaiveAccessPolicyProvider extends AbstractCognitoProvider im
         return accessPolicyBuilder.build();
     }
 
-
     protected Set<String> getPrincipalsInPolicy(GroupType groupType) throws AuthorizationAccessException {
         StopWatch watch = new StopWatch();
         final ListUsersInGroupRequest listUsersInGroupRequest = ListUsersInGroupRequest.builder()
@@ -248,7 +247,7 @@ public class CognitoNaiveAccessPolicyProvider extends AbstractCognitoProvider im
     }
 
     protected String getGroupName(String resource, RequestAction action) {
-        return String.join(":", policyGroupPrefix, action.toString(), resource);
+        return policyGroupPrefix + action + ":" + resource;
     }
 
     protected Map.Entry<String, RequestAction> getResourceAndAction(String groupName) {


### PR DESCRIPTION
The previous code did not correctly filter tenants if Tenant ID was ``.