### PR TITLE
Use Adaptive retry mode to handle throttled SDK calls

### DIFF
--- a/nifi-registry-cognito-extensions/src/main/java/co/zeroae/nifi/registry/authorization/cognito/AbstractCognitoProvider.java
+++ b/nifi-registry-cognito-extensions/src/main/java/co/zeroae/nifi/registry/authorization/cognito/AbstractCognitoProvider.java
@@ -8,7 +8,12 @@ import org.apache.nifi.registry.security.exception.SecurityProviderDestructionEx
 import org.apache.nifi.registry.util.FormatUtils;
 import org.apache.nifi.registry.util.PropertyValue;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.utils.StringUtils;
@@ -25,6 +30,7 @@ public abstract class AbstractCognitoProvider {
     static final String ACCESS_KEY_PROPS_NAME = "aws.access.key.id";
     static final String SECRET_KEY_PROPS_NAME = "aws.secret.access.key";
 
+    public static final int MAX_ATTEMPTS = 10;
     public static final int MAX_PAGE_SIZE = 60;
     public static final String PROP_USER_POOL_ID = "User Pool";
     public static final String PROP_TENANT_ID = "Tenant Id";
@@ -73,27 +79,34 @@ public abstract class AbstractCognitoProvider {
     }
 
     CognitoIdentityProviderClient configureClient(final String awsCredentialsFilename) throws IOException {
-        if (awsCredentialsFilename == null) {
-            return getDefaultClient();
+        final AwsCredentialsProvider credentialsProvider;
+        if (awsCredentialsFilename != null) {
+            final Properties properties = loadProperties(awsCredentialsFilename);
+            final String accessKey = properties.getProperty(AbstractCognitoProvider.ACCESS_KEY_PROPS_NAME);
+            final String secretKey = properties.getProperty(AbstractCognitoProvider.SECRET_KEY_PROPS_NAME);
+            if (org.apache.nifi.util.StringUtils.isNotBlank(accessKey) && org.apache.nifi.util.StringUtils.isNotBlank(secretKey)) {
+                final AwsBasicCredentials basicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+                credentialsProvider = StaticCredentialsProvider.create(basicCredentials);
+            } else {
+                credentialsProvider = DefaultCredentialsProvider.create();
+            }
+        } else {
+            credentialsProvider = DefaultCredentialsProvider.create();
         }
-        final Properties properties = loadProperties(awsCredentialsFilename);
-        final String accessKey = properties.getProperty(ACCESS_KEY_PROPS_NAME);
-        final String secretKey = properties.getProperty(SECRET_KEY_PROPS_NAME);
         final Region region = Region.of(userPoolId.substring(0, userPoolId.indexOf('_')));
+        final ClientOverrideConfiguration overrideConfiguration = ClientOverrideConfiguration.builder()
+                .retryPolicy(RetryPolicy.builder(RetryMode.ADAPTIVE)
+                        .additionalRetryConditionsAllowed(true)
+                        .fastFailRateLimiting(false)
+                        .numRetries(MAX_ATTEMPTS)
+                        .build()
+                )
+                .build();
 
-        AwsBasicCredentials basicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-        if (StringUtils.isNotBlank(accessKey) && StringUtils.isNotBlank(secretKey))
-            return CognitoIdentityProviderClient.builder()
-                    .region(region)
-                    .credentialsProvider(StaticCredentialsProvider.create(basicCredentials))
-                    .build();
-        else
-            return getDefaultClient();
-    }
-
-    private CognitoIdentityProviderClient getDefaultClient() {
         return CognitoIdentityProviderClient.builder()
-                .region(Region.of(userPoolId.substring(0, userPoolId.indexOf('_'))))
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .overrideConfiguration(overrideConfiguration)
                 .build();
     }
 


### PR DESCRIPTION
This PR handles the issues with Throttled Cognito API Exceptions

Despite using the caching system, we routinely get errors as such:
```
APP} 2022-07-28 17:56:18,914 WARN [Thread-28308] c.g.b.caffeine.cache.BoundedLocalCache Exception thrown during refresh
java.util.concurrent.CompletionException: org.apache.nifi.authorization.exception.AuthorizationAccessException: Too many requests (Service: CognitoIdentityProvider, Status Code: 400, Request ID: 53e6a79d-490a-41b4-954c-4cdece5f02d9)
at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1606)
at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.nifi.authorization.exception.AuthorizationAccessException: Too many requests (Service: CognitoIdentityProvider, Status Code: 400, Request ID: 53e6a79d-490a-41b4-954c-4cdece5f02d9)
at co.zeroae.nifi.authorization.cognito.CognitoNaiveAccessPolicyProvider.getAccessPolicy(CognitoNaiveAccessPolicyProvider.java:192)
at co.zeroae.nifi.authorization.cognito.CognitoAccessPolicyProvider.access$001(CognitoAccessPolicyProvider.java:18)
at co.zeroae.nifi.authorization.cognito.CognitoAccessPolicyProvider$1.load(CognitoAccessPolicyProvider.java:37)
at co.zeroae.nifi.authorization.cognito.CognitoAccessPolicyProvider$1.load(CognitoAccessPolicyProvider.java:33)
at com.github.benmanes.caffeine.cache.CacheLoader.reload(CacheLoader.java:166)
at com.github.benmanes.caffeine.cache.CacheLoader.lambda$asyncReload$2(CacheLoader.java:190)
at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
... 1 common frames omitted
Caused by: software.amazon.awssdk.services.cognitoidentityprovider.model.TooManyRequestsException: Too many requests (Service: CognitoIdentityProvider, Status Code: 400, Request ID: 53e6a79d-490a-41b4-954c-4cdece5f02d9)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleErrorResponse(CombinedResponseHandler.java:125)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handleResponse(CombinedResponseHandler.java:82)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:60)
at software.amazon.awssdk.core.internal.http.CombinedResponseHandler.handle(CombinedResponseHandler.java:41)
at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40)
at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)
at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)
at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81)
at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56)
at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:48)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:31)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:193)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:167)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:175)
at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)
at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)
at software.amazon.awssdk.services.cognitoidentityprovider.DefaultCognitoIdentityProviderClient.getGroup(DefaultCognitoIdentityProviderClient.java:4850)
at co.zeroae.nifi.authorization.cognito.CognitoNaiveAccessPolicyProvider.getAccessPolicy(CognitoNaiveAccessPolicyProvider.java:187)
... 7 common frames omitted
```